### PR TITLE
lib/bourne-shell : Blind fix for gentoo compatibility

### DIFF
--- a/lib/bourne-shell.sh
+++ b/lib/bourne-shell.sh
@@ -3,7 +3,7 @@
 # see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
 
 # make less more friendly for non-text input files, see lesspipe(1)
-[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+[ -x /usr/bin/lesspipe ] && eval "$(lesspipe)"
 
 # set variable identifying the chroot you work in (used in the prompt below)
 if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then


### PR DESCRIPTION
WARNING: Blind code!

Fixes: https://github.com/ohmybash/oh-my-bash/issues/46
Fixes: https://github.com/ohmybash/oh-my-bash/issues/69